### PR TITLE
fix(preprocessing): skip empty folders to prevent crash

### DIFF
--- a/pre_process_src/CollectTokensInFiles.py
+++ b/pre_process_src/CollectTokensInFiles.py
@@ -9,6 +9,10 @@ def merge_arrow_files(input_folder, output_file):
     input_files = [os.path.join(input_folder, f) for f in os.listdir(input_folder) if f.endswith('.arrow')]
     print(f"Found {len(input_files)} Arrow files in the folder.")
 
+    if len(input_files) == 0:
+        print(f"No arrow files found in {input_folder}. Skipping directory.")
+        return
+
     # get schema
     first_file = input_files[0]
     with pa.memory_map(first_file, 'r') as source:

--- a/pre_process_src/Tokenize.py
+++ b/pre_process_src/Tokenize.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import sys
+
 from os.path import join
 from multiprocessing import Pool
 from typing import Optional, List, Tuple
@@ -512,6 +514,10 @@ if __name__ == "__main__":
                 raise ValueError(f"TCP options are disabled, but file {filepath} has tcp options")
 
     print(f"Total files: {len(args)}")
+
+    if len(args) == 0:
+        print(f"No valid tokenizable files found in {input_dir}. Skipping directory.")
+        sys.exit(0)
 
     cores = script_args.cores
     if cores == 0:


### PR DESCRIPTION
This PR fixes an edge-case bug that causes the preprocessing phase to crash when handling PCAP files containing only invalid or truncated packets. I experienced this issue when processing the `mac_dos.pcap` file from the [TII-SSRC-23](https://www.kaggle.com/datasets/daniaherzalla/tii-ssrc-23) dataset.

If a raw PCAP file contains no packets that match the criteria in `1_filter.sh`, the filtering script outputs an empty 24-byte PCAP file ([the File Header only](https://www.ietf.org/archive/id/draft-gharris-opsawg-pcap-01.html#section-4-3)). Consequently, `2_pcap_splitting.sh` processes 0 flows and creates an empty target directory. When `Tokenize.py` runs on this directory, it counts zero files, dynamically selects zero cores, and attempts to divide the empty file list by 0 with NumPy's `array_split`, throwing a ValueError: number sections must be larger than 0. error.
```py
cores = script_args.cores
   if cores == 0:
       cores = min(os.cpu_count() - 2, len(args))
...
args = np.array_split(args, cores)
```

The issue is addressed by checking if the number of files is equal to zero before core calculation in `Tokenize.py` and before file merging in `CollectTokensInFiles.py`, and eventually exiting with status code `0`.